### PR TITLE
Use an LRU cache for translators

### DIFF
--- a/translate/final/app/src/main/java/com/google/firebase/mlkit/codelab/translate/ui/main/MainViewModel.kt
+++ b/translate/final/app/src/main/java/com/google/firebase/mlkit/codelab/translate/ui/main/MainViewModel.kt
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 Google Inc. All Rights Reserved.
  *
@@ -20,6 +19,7 @@ package com.google.firebase.mlkit.codelab.translate.ui.main
 
 import android.app.Application
 import android.os.Handler
+import android.util.LruCache
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -29,6 +29,7 @@ import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.ml.naturallanguage.FirebaseNaturalLanguage
 import com.google.firebase.ml.naturallanguage.translate.FirebaseTranslateLanguage
+import com.google.firebase.ml.naturallanguage.translate.FirebaseTranslator
 import com.google.firebase.ml.naturallanguage.translate.FirebaseTranslatorOptions
 import com.google.firebase.mlkit.codelab.translate.util.Language
 import com.google.firebase.mlkit.codelab.translate.util.ResultOrError
@@ -44,6 +45,22 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val modelDownloading = SmoothedMutableLiveData<Boolean>(SMOOTHING_DURATION)
 
     private var modelDownloadTask: Task<Void> = Tasks.forCanceled()
+
+    private val translators =
+        object : LruCache<FirebaseTranslatorOptions, FirebaseTranslator>(NUM_TRANSLATORS) {
+            override fun create(options: FirebaseTranslatorOptions): FirebaseTranslator {
+                return FirebaseNaturalLanguage.getInstance().getTranslator(options);
+            }
+
+            override fun entryRemoved(
+                evicted: Boolean,
+                key: FirebaseTranslatorOptions,
+                oldValue: FirebaseTranslator,
+                newValue: FirebaseTranslator?
+            ) {
+                oldValue.close();
+            }
+        }
 
     val sourceLang = Transformations.switchMap(sourceText) { text ->
         val result = MutableLiveData<Language>()
@@ -74,7 +91,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             .setSourceLanguage(sourceLangCode)
             .setTargetLanguage(targetLangCode)
             .build()
-        val translator = FirebaseNaturalLanguage.getInstance().getTranslator(options)
+        val translator = translators[options];
         modelDownloading.setValue(true)
 
         // Register watchdog to unblock long running downloads
@@ -119,5 +136,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     companion object {
         // Amount of time (in milliseconds) to wait for detected text to settle
         private const val SMOOTHING_DURATION = 50L
+
+        private const val NUM_TRANSLATORS = 1
     }
 }

--- a/translate/final/app/src/main/java/com/google/firebase/mlkit/codelab/translate/ui/main/MainViewModel.kt
+++ b/translate/final/app/src/main/java/com/google/firebase/mlkit/codelab/translate/ui/main/MainViewModel.kt
@@ -49,7 +49,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val translators =
         object : LruCache<FirebaseTranslatorOptions, FirebaseTranslator>(NUM_TRANSLATORS) {
             override fun create(options: FirebaseTranslatorOptions): FirebaseTranslator {
-                return FirebaseNaturalLanguage.getInstance().getTranslator(options);
+                return FirebaseNaturalLanguage.getInstance().getTranslator(options)
             }
 
             override fun entryRemoved(
@@ -58,7 +58,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 oldValue: FirebaseTranslator,
                 newValue: FirebaseTranslator?
             ) {
-                oldValue.close();
+                oldValue.close()
             }
         }
 
@@ -91,7 +91,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             .setSourceLanguage(sourceLangCode)
             .setTargetLanguage(targetLangCode)
             .build()
-        val translator = translators[options];
+        val translator = translators[options]
         modelDownloading.setValue(true)
 
         // Register watchdog to unblock long running downloads

--- a/translate/final/build.gradle
+++ b/translate/final/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.2'
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Translator instances are cached internally by the ML Kit SDK, but using the LRU
cache allows observing evictions to close translators when they're not needed
anymore.